### PR TITLE
display mini help if no tool was provided

### DIFF
--- a/docs/00_help.md
+++ b/docs/00_help.md
@@ -1,0 +1,22 @@
+**Missing Toolname**
+
+Use one of the tool names.
+
+- addkey - add a new key to a JWKS
+- newkey - create a new JWK key
+- listkeys - list the key ids for all keys in a JWKS
+- findkey - find a kid in a JWKS
+- rmkey - remove a kid from a JWKS
+- thumbprint - generate the thumbprint for a key
+- info - return basic information about a JWT without processing it
+- digest - runs a selected hashing algorithm on the provided data.
+- sign - creates and signs a JWS for a given payload
+- verify - verifies a JWS and return the payload
+- encrypt - encrypt a payload into a JWE
+- decrypt - decrypts a JWE and returns the payload
+
+For more details run  
+
+```
+jose TOOLNAME --help
+```

--- a/index.js
+++ b/index.js
@@ -4,9 +4,22 @@
 require("./lib/helper/sanitize.js")(process.argv[2])
     // include and run the tool
     .then((tool) => require(`./lib/${tool}`)(process.argv.slice(3)))
+    // gracefully fail on error
+    .catch((err) => {
+        // show mini help
+        if (err.message === "missing toolname") {
+            return require("./lib/helper/loaddoc.js")("00_help");
+        }
+        // show full help if requested
+        else if (err.message === "basic help") {
+            return require("./lib/helper/loaddoc.js")("00_INDEX");
+        }
+        else {
+            throw err;
+        }
+    })
     // print on success
     .then((data) => process.stdout.write(data, "utf8"))
-    // gracefully fail on error
     .catch((err) => {
         // process.stderr.write(err.message);
         console.log(err.message); // eslint-disable-line no-console

--- a/lib/helper/loaddoc.js
+++ b/lib/helper/loaddoc.js
@@ -10,7 +10,7 @@ marked.setOptions({
     })
 });
 
-module.exports = async function showDoc(toolname, docdir = "docs/") {
+module.exports = async function showDoc(toolname, docdir = `${__dirname}/../../docs/`) {
     const data = await new Promise((resolve,reject) => {
         fs.readFile(`${docdir}${toolname}.md`, (err, data) => {
             if (err) {

--- a/lib/helper/sanitize.js
+++ b/lib/helper/sanitize.js
@@ -6,6 +6,10 @@ module.exports = async function sanitize(toolname) {
         throw new Error("missing toolname");
     }
 
+    if (toolname === "--help" || toolname === "-h") {
+        throw new Error("basic help");
+    }
+
     toolname = toolname.replace(/\./g, ""); // drop all dots
     toolname = toolname.replace(/\//g, "-"); // replace all slashed with dashes
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "mock-stdin": "1.0.0"
   },
   "bin": {
-    "jose": "./index.js"
+    "jose": "index.js"
   }
 }


### PR DESCRIPTION
fixes #105

and fixes that the help file is never displayed if not run in the build directory. 